### PR TITLE
Docs Graph

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+# include pdf and epub
+formats: all
+
+python:
+  version: 3.7
+  install:
+    # pip will handle our pyproject.toml
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -1,6 +1,12 @@
 API Reference
 =============
 
+.. inheritance-diagram::
+   happyly.listening.executor.Executor
+   happyly.listening.listener.EarlyAckListener
+   happyly.listening.listener.LateAckListener
+   :parts: -1
+
 .. autosummary::
    :toctree: _autosummary
 

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -2,9 +2,19 @@ API Reference
 =============
 
 .. inheritance-diagram::
-   happyly.listening.executor.Executor
-   happyly.listening.listener.EarlyAckListener
-   happyly.listening.listener.LateAckListener
+   happyly.Executor
+   happyly.listening.EarlyAckListener
+   happyly.listening.LateAckListener
+   happyly.Schema
+   happyly.Cacher
+   happyly.caching.mixins.CacheByRequestIdMixin
+   happyly.Serializer
+   happyly.Deserializer
+   happyly.Handler
+   happyly.handling.HandlingResult
+   happyly.handling.HandlingResultStatus
+   happyly.handling.dummy_handler._DummyHandler
+   happyly.exceptions
    :parts: -1
 
 .. autosummary::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,6 +94,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
+    'sphinx.ext.graphviz',
+    'sphinx.ext.inheritance_diagram',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,22 +19,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-if os.environ.get('READTHEDOCS'):
-    # We want to make sure all dependencies are installed.
-    # ReadTheDocs supports only requirements.txt but not other formats,
-    # so use this trick:
-    # first use pip to install flit in our virtualenv...
-    from pip._internal import main as pipmain
-
-    pipmain(['install', 'flit'])
-    # workaround for pip#5882
-    os.environ.pop('PIP_REQ_TRACKER', None)
-
-    # ...and then use flit to install the package and all its dependencies
-    import flit
-
-    flit.main(['-f', '../pyproject.toml', 'install', '--extras=all'])
-
 
 # workaround python-attrs/attrs#523
 # (it hides some class attributes in members summary)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -264,6 +264,12 @@ intersphinx_mapping = {
 todo_include_todos = True
 
 
+# -- Options for graphviz and inheritance_diagram
+
+# Use SVG rather than PNG: nowadays anyone should support SVG, right?
+graphviz_output_format = 'svg'
+
+
 # Enhance sphinx_autodoc_typehints with support for class fields.
 # This implementation is somewhat dirty;
 # probably we should improve it and make a PR?

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -35,7 +35,7 @@ Use cases
     def callback(message):
         attributes = json.loads(message.data)
         try:
-            result = process_things(attributes['ID'])    
+            result = process_things(attributes['ID'])
             encoded = json.dumps(result).encode('utf-8')
             PUBLISHER.publish(TOPIC, encoded)
         except NeedToRetry:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# ReadTheDocs does not properly support our requirements in pyproject.toml,
+# and our workaround in conf.py does not allow us to reliably update Sphinx itself.
+# So use this rudimentary file.
+sphinx>=2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-# ReadTheDocs does not properly support our requirements in pyproject.toml,
-# and our workaround in conf.py does not allow us to reliably update Sphinx itself.
-# So use this rudimentary file.
-sphinx>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
     "pytest>=4.3.0", "tox>=3.7.0",
 ]
 doc = [
-    "sphinx>=1.8.5",
+    "sphinx>=2.0.0",
     "sphinx-rtd-theme>=0.4.3",
     "sphinx-autodoc-typehints>=1.6.0",
 ]


### PR DESCRIPTION
After finishing, <strike>this should f i x #9</strike>.
For now this is still WiP, please review.
Current version of class hierarchy diagram is available on `api reference` page:
https://happyly.readthedocs.io/en/docs-graph/apidoc.html

(right now it is not shown; working on this)